### PR TITLE
Make the first color the outermost scope, the 2nd color the next scope

### DIFF
--- a/autoload/rainbow_parentheses.vim
+++ b/autoload/rainbow_parentheses.vim
@@ -21,7 +21,7 @@ let s:rpairs = [
 	\ ['darkcyan',    'DarkOrchid3'],
 	\ ['red',         'firebrick3'],
 	\ ]
-let s:pairs = exists('g:rbpt_colorpairs') ? reverse(g:rbpt_colorpairs) : reverse(s:pairs)
+let s:pairs = exists('g:rbpt_colorpairs') ? reverse(g:rbpt_colorpairs) : reverse(s:rpairs)
 let s:max = exists('g:rbpt_max') ? g:rbpt_max : max([len(s:pairs), 15])
 let s:loadtgl = exists('g:rbpt_loadcmd_toggle') ? g:rbpt_loadcmd_toggle : 0
 let s:types = [['(',')'],['\[','\]'],['{','}'],['<','>']]


### PR DESCRIPTION
The original behavior is a bit chaotic due to an interaction with the
max trimming function (and being backwards to boot)

![samplecolorsetup](https://cloud.githubusercontent.com/assets/271309/4832860/ce1a00c8-5f9f-11e4-902e-e74d3bf085fd.png)
![oldbehaviorvisualization](https://cloud.githubusercontent.com/assets/271309/4832862/d0f9d606-5f9f-11e4-9189-973a81b46eb6.png)
![newbehaviorvisualization](https://cloud.githubusercontent.com/assets/271309/4832863/d1098ac4-5f9f-11e4-92f8-5e737df1b14b.png)
