### PR TITLE
add installation instructions to readme 

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@ appears to be unmaintained.
 
 ### Installation 
 
-Using [pathogen.vim]('https://github.com/tpope/vim-pathogen'):
+Using [pathogen.vim](https://github.com/tpope/vim-pathogen):
 
 ```
 cd ~/.vim/bundle

--- a/readme.md
+++ b/readme.md
@@ -3,6 +3,15 @@
 Forked from https://github.com/kien/rainbow_parentheses.vim since that now
 appears to be unmaintained.
 
+### Installation 
+
+Using [pathogen.vim]('https://github.com/tpope/vim-pathogen'):
+
+```
+cd ~/.vim/bundle
+git clone git://github.com/eapache/rainbow_parentheses.vim.git
+```
+
 ### Options:
 
 The colours used; the outermost pair is coloured with the last colour in the
@@ -54,6 +63,8 @@ let g:bold_parentheses = 1      " Default on
 ```
 
 ### Always On:
+
+Add the following to your `~/.vimrc` to always use Rainbow Parenthesis
 
 ```vim
 au VimEnter * RainbowParenthesesToggle


### PR DESCRIPTION
I was at first unsure how to install this plugin, so I added installation instructions using vim pathogen. 
Also added a useful pointer to the "Always On" section of the readme. 