### PR TITLE
Fix deep coloring

### DIFF
--- a/autoload/rainbow_parentheses.vim
+++ b/autoload/rainbow_parentheses.vim
@@ -22,7 +22,8 @@ let s:rpairs = [
 	\ ['red',         'firebrick3'],
 	\ ]
 let s:pairs = exists('g:rbpt_colorpairs') ? reverse(g:rbpt_colorpairs) : reverse(s:rpairs)
-let s:max = exists('g:rbpt_max') ? g:rbpt_max : max([len(s:pairs), 15])
+let s:max_depth = max([len(s:pairs), 15])
+let s:max = exists('g:rbpt_max') ? g:rbpt_max : s:max_depth
 let s:loadtgl = exists('g:rbpt_loadcmd_toggle') ? g:rbpt_loadcmd_toggle : 0
 let s:types = [['(',')'],['\[','\]'],['{','}'],['<','>']]
 let s:bold = exists('g:bold_parentheses') ? g:bold_parentheses : 1
@@ -38,17 +39,19 @@ endfunc
 cal s:extend()
 
 func! rainbow_parentheses#activate()
-	let [id, s:active] = [1, 1]
+	let [id, s:active] = [s:max_depth, 1]
 	let bold = s:bold ? ' cterm=bold gui=bold' : ''
 	for [ctermfg, guifg] in s:pairs
 		exe 'hi default level'.id.'c ctermfg='.ctermfg.' guifg='.guifg.bold
-		let id += 1
+		let id -= 1
 	endfor
 endfunc
 
 func! rainbow_parentheses#clear()
+	let id = s:max_depth
 	for each in range(1, s:max)
-		exe 'hi clear level'.each.'c'
+		exe 'hi clear level'.id.'c'
+		let id -= 1
 	endfor
 	let s:active = 0
 endfunc
@@ -82,12 +85,12 @@ cal s:cluster()
 
 func! rainbow_parentheses#load(...)
 	let [level, grp, type] = ['', '', s:types[a:1]]
-	let alllvls = map(range(1, s:max), '"level".v:val')
+	let alllvls = map(range(1, s:max_depth), '"level".v:val')
 	if !exists('b:loaded')
 		let b:loaded = [0,0,0,0]
 	endif
 	let b:loaded[a:1] = s:loadtgl && b:loaded[a:1] ? 0 : 1
-	for each in range(1, s:max)
+	for each in range(1, s:max_depth)
 		let region = 'level'. each .(b:loaded[a:1] ? '' : 'none')
 		let grp = b:loaded[a:1] ? 'level'.each.'c' : 'Normal'
 		let cmd = 'sy region %s matchgroup=%s start=/%s/ end=/%s/ contains=TOP,%s,NoInParens fold'

--- a/autoload/rainbow_parentheses.vim
+++ b/autoload/rainbow_parentheses.vim
@@ -39,19 +39,17 @@ endfunc
 cal s:extend()
 
 func! rainbow_parentheses#activate()
-	let [id, s:active] = [s:max_depth, 1]
+	let [id, s:active] = [1, 1]
 	let bold = s:bold ? ' cterm=bold gui=bold' : ''
 	for [ctermfg, guifg] in s:pairs
 		exe 'hi default level'.id.'c ctermfg='.ctermfg.' guifg='.guifg.bold
-		let id -= 1
+		let id += 1
 	endfor
 endfunc
 
 func! rainbow_parentheses#clear()
-	let id = s:max_depth
 	for each in range(1, s:max)
-		exe 'hi clear level'.id.'c'
-		let id -= 1
+		exe 'hi clear level'.each.'c'
 	endfor
 	let s:active = 0
 endfunc
@@ -90,12 +88,12 @@ func! rainbow_parentheses#load(...)
 		let b:loaded = [0,0,0,0]
 	endif
 	let b:loaded[a:1] = s:loadtgl && b:loaded[a:1] ? 0 : 1
-	for each in range(1, s:max_depth)
+	for each in reverse(range(1, s:max_depth))
 		let region = 'level'. each .(b:loaded[a:1] ? '' : 'none')
 		let grp = b:loaded[a:1] ? 'level'.each.'c' : 'Normal'
 		let cmd = 'sy region %s matchgroup=%s start=/%s/ end=/%s/ contains=TOP,%s,NoInParens fold'
 		exe printf(cmd, region, grp, type[0], type[1], join(alllvls, ','))
-		cal remove(alllvls, 0)
+		cal remove(alllvls, -1)
 	endfor
 endfunc
 

--- a/autoload/rainbow_parentheses.vim
+++ b/autoload/rainbow_parentheses.vim
@@ -4,7 +4,7 @@
 "               2011-10-12: Use less code.  Leave room for deeper levels.
 "==============================================================================
 
-let s:rpairs = [
+let s:pairs = [
 	\ ['red',         'RoyalBlue3'],
 	\ ['brown',       'SeaGreen3'],
 	\ ['blue',        'DarkOrchid3'],
@@ -21,7 +21,7 @@ let s:rpairs = [
 	\ ['darkcyan',    'DarkOrchid3'],
 	\ ['red',         'firebrick3'],
 	\ ]
-let s:pairs = exists('g:rbpt_colorpairs') ? reverse(g:rbpt_colorpairs) : reverse(s:rpairs)
+let s:pairs = exists('g:rbpt_colorpairs') ? g:rbpt_colorpairs : s:pairs
 let s:max_depth = max([len(s:pairs), 15])
 let s:max = exists('g:rbpt_max') ? g:rbpt_max : s:max_depth
 let s:loadtgl = exists('g:rbpt_loadcmd_toggle') ? g:rbpt_loadcmd_toggle : 0


### PR DESCRIPTION
Right now, multiple things are not working as expected (or making it harder for the end user to configure colors), especially when `g:rbpt_max` is set; this PR tries to address these annoyances.

1. Unbalanced parentheses

Set `g:rbpt_max = 1`, and matching parentheses would not get the same color.  A possible fix for this is to make sure the plugin defines **all** the `syn regions`, but only assign colors up to a certain level.

2. Color pairs are not used in the _expected_ order

The first color pair should be used for the outermost pair of parentheses.

3. Change the order of 'syn region' definitions

Again, `level1c` should refer to the outermost pair of parentheses.  This comes in handy for users that want to override colors without redefining `g:rbpt_colorpairs`.

